### PR TITLE
Issue 1:  Background Viewport Flickering Problem

### DIFF
--- a/data/project.json
+++ b/data/project.json
@@ -11,7 +11,7 @@
         "resize_type": "viewport-dimensions",
         "resize_mode": "expand-horizontally",
         "render_type": "addition",
-        "fps_cap": 60,
+        "fps_cap": 30,
         "render_scale": 1.0
     },
 

--- a/data/test_scene_2.json
+++ b/data/test_scene_2.json
@@ -62,42 +62,6 @@
         },
 
         {
-            "name": "viewport_3D",
-            "parent": "/",
-            "type": "ViewportNode",
-            "components": [
-                {
-                    "type": "Placement",
-                    "orientation": [
-                        1.0, 0.0, 0.0, 0.0
-                    ],
-                    "position": [
-                        0.0, 0.0, 0.0, 1.0
-                    ],
-                    "scale": [
-                        1.0, 1.0, 1.0
-                    ]
-                }
-            ],
-            "inherits_world": false,
-            "render_configuration": {
-                "base_dimensions": [800, 600],
-                "update_mode": "on-render-cap-fps",
-                "resize_type": "texture-dimensions",
-                "resize_mode": "fixed-dimensions",
-                "render_type": "basic-3d",
-                "fps_cap": 60,
-                "render_scale": 1.0
-            }
-        },
-        {
-            "type": "Scene",
-            "name": "testSubscene3D",
-            "parent": "/viewport_3D/",
-            "copy": false
-        },
-
-        {
             "name": "viewport_UI",
             "parent": "/",
             "type": "ViewportNode",
@@ -122,7 +86,7 @@
                 "resize_type": "texture-dimensions",
                 "resize_mode": "fixed-dimensions",
                 "render_type": "basic-3d",
-                "fps_cap": 60,
+                "fps_cap": 30,
                 "render_scale": 1.0
             }
         },
@@ -169,6 +133,42 @@
             "name": "dumbUIText",
             "parent": "/viewport_UI/",
             "copy": true 
+        },
+
+        {
+            "name": "viewport_3D",
+            "parent": "/",
+            "type": "ViewportNode",
+            "components": [
+                {
+                    "type": "Placement",
+                    "orientation": [
+                        1.0, 0.0, 0.0, 0.0
+                    ],
+                    "position": [
+                        0.0, 0.0, 0.0, 1.0
+                    ],
+                    "scale": [
+                        1.0, 1.0, 1.0
+                    ]
+                }
+            ],
+            "inherits_world": false,
+            "render_configuration": {
+                "base_dimensions": [800, 600],
+                "update_mode": "on-render-cap-fps",
+                "resize_type": "texture-dimensions",
+                "resize_mode": "fixed-dimensions",
+                "render_type": "basic-3d",
+                "fps_cap": 30,
+                "render_scale": 1.0
+            }
+        },
+        {
+            "type": "Scene",
+            "name": "testSubscene3D",
+            "parent": "/viewport_3D/",
+            "copy": false
         }
     ],
 

--- a/src/app/test_text.cpp
+++ b/src/app/test_text.cpp
@@ -71,7 +71,6 @@ void TestText::recomputeTexture() {
             {"flip_texture_y", true}
         }}
     };
-    std::cout << "Rectangle parameters: \n" << nlohmann::to_string(rectangleParameters) << "\n";
 
     if(!hasComponent<std::shared_ptr<StaticModel>>()) {
         addComponent<std::shared_ptr<StaticModel>>(

--- a/src/engine/render_stage.cpp
+++ b/src/engine/render_stage.cpp
@@ -290,6 +290,7 @@ void LightingRenderStage::execute() {
 
     glDisable(GL_FRAMEBUFFER_SRGB);
     glDisable(GL_DEPTH_TEST);
+    // glDisable(GL_BLEND);
     glEnable(GL_BLEND);
     glBlendFunc(GL_ONE, GL_ONE);
 
@@ -421,9 +422,9 @@ void BlurRenderStage::execute() {
                 {"UV1", LOCATION_UV1, 2, GL_FLOAT}
             }});
             for(int i{0}; i < nPasses; ++i) {
-                glDrawElements(
+                glDrawElementsInstanced(
                     GL_TRIANGLES, screenMeshHandle->getElementCount(), 
-                    GL_UNSIGNED_INT, nullptr
+                    GL_UNSIGNED_INT, nullptr, 1
                 );
 
                 // Prepare for the next pass, flipping color buffers
@@ -530,40 +531,49 @@ void AdditionRenderStage::execute() {
     std::shared_ptr<Material> screenMaterial {getMaterial("screenMaterial")};
 
     glDisable(GL_DEPTH_TEST);
-    glEnable(GL_FRAMEBUFFER_SRGB);
-    glEnable(GL_BLEND);
-    glBlendEquationSeparate(GL_FUNC_ADD, GL_MAX);
-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
-
-    std::size_t textureAddendIndex { 0 };
-    std::string textureAddendName { std::string{"textureAddend_"} + std::to_string(textureAddendIndex) };
+    glDisable(GL_FRAMEBUFFER_SRGB);
+    glDisable(GL_BLEND);
 
     mFramebufferHandle->bind();
         glClear(GL_COLOR_BUFFER_BIT);
-        while(mTextureAttachments.find(textureAddendName) != mTextureAttachments.end()) {
+
+        std::size_t nCombineTextures { 0 };
+        std::string textureAddendName {
+            std::string{"textureAddend_"}
+            + std::to_string(nCombineTextures)
+        };
+        while(nCombineTextures < 4 && mTextureAttachments.find(textureAddendName) != mTextureAttachments.end()) {
             std::shared_ptr<Texture> currentTextureAttachment { mTextureAttachments.at(textureAddendName) };
 
-            currentTextureAttachment->bind(0);
-            mShaderHandle->setUInt("uGenericTexture", 0);
-            glBindVertexArray(mVertexArrayObject);
-                mMeshAttachments.at("screenMesh")->bind({{
-                    {"position", LOCATION_POSITION, 4, GL_FLOAT},
-                    {"color", LOCATION_COLOR, 4, GL_FLOAT},
-                    {"UV1", LOCATION_UV1, 2, GL_FLOAT},
-                }});
-                glDrawElementsInstanced(
-                    GL_TRIANGLES,
-                    mMeshAttachments.at("screenMesh")->getElementCount(),
-                    GL_UNSIGNED_INT,
-                    nullptr,
-                    1
-                );
-            glBindVertexArray(0);
+            const std::string samplerUniformName {
+                std::string{"uCombineTextures["}
+                + std::to_string(nCombineTextures)
+                + std::string{"]"}
+            };
+            currentTextureAttachment->bind(nCombineTextures);
+            mShaderHandle->setUInt(samplerUniformName, nCombineTextures);
 
-            ++textureAddendIndex;
-            textureAddendName = std::string{"textureAddend_"} + std::to_string(textureAddendIndex);
+            textureAddendName = std::string{"textureAddend_"} + std::to_string(++nCombineTextures);
         }
+        mShaderHandle->setUInt("nCombine", nCombineTextures);
+
+        glBindVertexArray(mVertexArrayObject);
+            mMeshAttachments.at("screenMesh")->bind({{
+                {"position", LOCATION_POSITION, 4, GL_FLOAT},
+                {"UV1", LOCATION_UV1, 2, GL_FLOAT},
+            }});
+            glDrawElementsInstanced(
+                GL_TRIANGLES,
+                mMeshAttachments.at("screenMesh")->getElementCount(),
+                GL_UNSIGNED_INT,
+                nullptr,
+                1
+            );
+        glBindVertexArray(0);
+
+
     mFramebufferHandle->unbind();
+    mTextureAttachments.clear();
 }
 
 void ScreenRenderStage::setup(const glm::u16vec2& targetDimensions) {
@@ -589,7 +599,6 @@ void ScreenRenderStage::execute() {
         mShaderHandle->setUInt("uGenericTexture", 0);
         mMeshAttachments.at("screenMesh")->bind({{
             {"position", LOCATION_POSITION, 4, GL_FLOAT},
-            {"color", LOCATION_COLOR, 4, GL_FLOAT},
             {"UV1", LOCATION_UV1, 2, GL_FLOAT}
         }});
         glDrawElementsInstanced(
@@ -631,11 +640,15 @@ void ResizeRenderStage::execute() {
     mFramebufferHandle->bind();
         glClear(GL_COLOR_BUFFER_BIT);
         glBindVertexArray(mVertexArrayObject);
+            std::cout 
+                << "\trendering texture " << mTextureAttachments.at("renderSource")->getTextureID() 
+                << " to " << mFramebufferHandle->getTargetColorBufferHandles().at(0)->getTextureID()
+                << std::endl;
+
             mTextureAttachments.at("renderSource")->bind(0);
             mShaderHandle->setUInt("uGenericTexture", 0);
             mMeshAttachments.at("screenMesh")->bind({{
                 {"position", LOCATION_POSITION, 4, GL_FLOAT},
-                {"color", LOCATION_COLOR, 4, GL_FLOAT},
                 {"UV1", LOCATION_UV1, 2, GL_FLOAT}
             }});
             glDrawElementsInstanced(

--- a/src/engine/render_stage.cpp
+++ b/src/engine/render_stage.cpp
@@ -319,8 +319,8 @@ void LightingRenderStage::execute() {
             }
 
             mShaderHandle->use();
-            std::vector<std::string> gBufferAliases {
-                {"positionMap"}, {"normalMap"}, {"albedoSpecularMap"}
+            const std::array<const std::string, 3> gBufferAliases {
+                "positionMap", "normalMap", "albedoSpecularMap"
             };
             for(int i{0}; i < 3; ++i) {
                 mTextureAttachments.at(gBufferAliases[i])->bind(i);
@@ -640,11 +640,6 @@ void ResizeRenderStage::execute() {
     mFramebufferHandle->bind();
         glClear(GL_COLOR_BUFFER_BIT);
         glBindVertexArray(mVertexArrayObject);
-            std::cout 
-                << "\trendering texture " << mTextureAttachments.at("renderSource")->getTextureID() 
-                << " to " << mFramebufferHandle->getTargetColorBufferHandles().at(0)->getTextureID()
-                << std::endl;
-
             mTextureAttachments.at("renderSource")->bind(0);
             mShaderHandle->setUInt("uGenericTexture", 0);
             mMeshAttachments.at("screenMesh")->bind({{

--- a/src/engine/render_stage.hpp
+++ b/src/engine/render_stage.hpp
@@ -261,7 +261,7 @@ public:
             {"colorBufferDefinitions", {
                 ColorBufferDefinition {
                     .mDataType=GL_UNSIGNED_BYTE,
-                    .mComponentCount=4
+                    .mComponentCount=4,
                 },
             }},
         }},
@@ -301,7 +301,6 @@ public:
                 ColorBufferDefinition{
                     .mDataType=GL_UNSIGNED_BYTE,
                     .mComponentCount=4,
-                    .mUsesWebColors=true
                 },
             }},
         }}

--- a/src/engine/render_system.cpp
+++ b/src/engine/render_system.cpp
@@ -101,6 +101,7 @@ void RenderSystem::execute(float simulationProgress) {
             }
 
             mRenderSets.at(mActiveRenderSetID).mAdditionRenderStage->execute();
+
         break;
     }
 
@@ -153,7 +154,7 @@ RenderSetID RenderSystem::createRenderSet(glm::u16vec2 renderDimensions, glm::u1
     newRenderSet.mTonemappingRenderStage = std::make_shared<TonemappingRenderStage>( "src/shader/tonemappingShader.json" );
     newRenderSet.mResizeRenderStage = std::make_shared<ResizeRenderStage>("src/shader/basicShader.json");
     newRenderSet.mScreenRenderStage = std::make_shared<ScreenRenderStage>("src/shader/basicShader.json");
-    newRenderSet.mAdditionRenderStage = std::make_shared<AdditionRenderStage>("src/shader/basicShader.json");
+    newRenderSet.mAdditionRenderStage = std::make_shared<AdditionRenderStage>("src/shader/combineShader.json");
 
     newRenderSet.mLightMaterialHandle = ResourceDatabase::ConstructAnonymousResource<Material>({
         {"type", Material::getResourceTypeName()},
@@ -266,6 +267,7 @@ std::shared_ptr<Texture> RenderSystem::getCurrentScreenTexture() {
 
 std::shared_ptr<Texture> RenderSet::getCurrentScreenTexture() {
     if(mRerendered) {
+        std::cout << "\tExecuting copy and resize on screen texture: " << mCurrentScreenTexture << std::endl;
         copyAndResize();
         mRerendered = false;
     }

--- a/src/engine/render_system.cpp
+++ b/src/engine/render_system.cpp
@@ -38,6 +38,8 @@ void RenderSystem::LightQueue::onInitialize() {
 
 void RenderSystem::onInitialize() {
     // Set up a uniform buffer for shared matrices
+    // TODO: Is there a generalization or abstraction for the problem of uniform buffers that
+    // could be useful going forward?
     glGenBuffers(1, &mMatrixUniformBufferIndex);
     glBindBuffer(GL_UNIFORM_BUFFER, mMatrixUniformBufferIndex);
         glBufferData(
@@ -48,14 +50,6 @@ void RenderSystem::onInitialize() {
         );
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
-    // Bind the shared matrix uniform buffer to the same binding point
-    glBindBufferRange(
-        GL_UNIFORM_BUFFER,
-        mMatrixUniformBufferBinding,
-        mMatrixUniformBufferIndex,
-        0,
-        2*sizeof(glm::mat4)
-    );
     if(!ResourceDatabase::HasResourceDescription("screenRectangleMesh")) {
         nlohmann::json rectangleMeshDefinition {
             {"name", "screenRectangleMesh"},
@@ -83,8 +77,18 @@ void RenderSystem::execute(float simulationProgress) {
 
     // Execute each rendering stage in its proper order
     switch(mRenderSets.at(mActiveRenderSetID).mRenderType) {
-
         case RenderSet::RenderType::BASIC_3D:
+            // Bind the shared matrix uniform buffer to the camera matrix binding point
+            // TODO: Is there a generalization or abstraction for the problem of uniform buffers that
+            // could be useful going forward?
+            glBindBufferRange(
+                GL_UNIFORM_BUFFER,
+                mMatrixUniformBufferBinding,
+                mMatrixUniformBufferIndex,
+                0,
+                2*sizeof(glm::mat4)
+            );
+
             mWorld.lock()->getSystem<OpaqueQueue>()->enqueueTo(*mRenderSets.at(mActiveRenderSetID).mGeometryRenderStage, simulationProgress);
             mRenderSets.at(mActiveRenderSetID).mGeometryRenderStage->execute();
             mWorld.lock()->getSystem<LightQueue>()->enqueueTo(*mRenderSets.at(mActiveRenderSetID).mLightingRenderStage, simulationProgress);
@@ -101,7 +105,6 @@ void RenderSystem::execute(float simulationProgress) {
             }
 
             mRenderSets.at(mActiveRenderSetID).mAdditionRenderStage->execute();
-
         break;
     }
 
@@ -116,6 +119,8 @@ void RenderSystem::execute(float simulationProgress) {
 void RenderSystem::updateCameraMatrices(float simulationProgress) {
     CameraProperties cameraProps { getComponent<CameraProperties>(mRenderSets[mActiveRenderSetID].mActiveCamera, simulationProgress) };
     // Send shared matrices to the uniform buffer
+    // TODO: Is there a generalization or abstraction for the problem of uniform buffers that
+    // could be useful going forward?
     glBindBuffer(GL_UNIFORM_BUFFER, mMatrixUniformBufferIndex);
 
         glBufferSubData(
@@ -256,8 +261,6 @@ void RenderSystem::renderNextTexture() {
 }
 void RenderSet::renderNextTexture() {
     mCurrentScreenTexture = (mCurrentScreenTexture + 1) % mScreenTextures.size();
-    mResizeRenderStage->attachTexture("renderSource", mScreenTextures[mCurrentScreenTexture]);
-    mResizeRenderStage->validate();
     mRerendered=true;
 }
 
@@ -267,7 +270,6 @@ std::shared_ptr<Texture> RenderSystem::getCurrentScreenTexture() {
 
 std::shared_ptr<Texture> RenderSet::getCurrentScreenTexture() {
     if(mRerendered) {
-        std::cout << "\tExecuting copy and resize on screen texture: " << mCurrentScreenTexture << std::endl;
         copyAndResize();
         mRerendered = false;
     }
@@ -285,6 +287,8 @@ void RenderSystem::copyAndResize() {
 }
 
 void RenderSet::copyAndResize() {
+    mResizeRenderStage->attachTexture("renderSource", mScreenTextures[mCurrentScreenTexture]);
+    mResizeRenderStage->validate();
     mResizeRenderStage->execute();
 }
 

--- a/src/engine/render_system.hpp
+++ b/src/engine/render_system.hpp
@@ -25,7 +25,7 @@ struct RenderSet {
     };
 
     void renderNextTexture ();
-    void setRenderProperties(glm::u16vec2 renderDimensions, glm::u16vec2 targetDimensions, const SDL_Rect& viewportDimensions, RenderType renderType=RenderType::BASIC_3D);
+    void setRenderProperties(glm::u16vec2 renderDimensions, glm::u16vec2 targetDimensions, const SDL_Rect& viewportDimensions, RenderType renderType);
     std::shared_ptr<Texture> getCurrentScreenTexture ();
     void copyAndResize();
     void addOrAssignRenderSource(const std::string& name, std::shared_ptr<Texture> renderSource);
@@ -102,7 +102,7 @@ public:
     void removeRenderSource(const std::string& name);
 
     void useRenderSet(RenderSetID renderSet);
-    void setRenderProperties(glm::u16vec2 renderDimensions, glm::u16vec2 targetDimensions, const SDL_Rect& viewportDimensions, RenderSet::RenderType renderType=RenderSet::RenderType::BASIC_3D);
+    void setRenderProperties(glm::u16vec2 renderDimensions, glm::u16vec2 targetDimensions, const SDL_Rect& viewportDimensions, RenderSet::RenderType renderType);
     void deleteRenderSet(RenderSetID renderSet);
 
     // Render set functions

--- a/src/engine/scene_system.cpp
+++ b/src/engine/scene_system.cpp
@@ -574,7 +574,7 @@ void ViewportNode::requestDimensions(glm::u16vec2 requestDimensions) {
             );
         break;
         case RenderConfiguration::ResizeType::TEXTURE_DIMENSIONS:
-           renderSystem->setRenderProperties(
+            renderSystem->setRenderProperties(
                 glm::mat2{mRenderConfiguration.mRenderScale} * mRenderConfiguration.mBaseDimensions,
                 requestDimensions,
                 {
@@ -653,7 +653,6 @@ std::shared_ptr<SceneNodeCore> ViewportNode::findFallbackCamera() {
 std::shared_ptr<Texture> ViewportNode::fetchRenderResult(float simulationProgress) {
     assert(mRenderConfiguration.mFPSCap > 0.f && "FPS cannot be negative or zero");
     const uint32_t thresholdTime {static_cast<uint32_t>(1000 / mRenderConfiguration.mFPSCap)};
-    std::shared_ptr<ECSWorld> world = getWorld().lock();
 
     switch (mRenderConfiguration.mUpdateMode) {
         case RenderConfiguration::UpdateMode::ON_FETCH_CAP_FPS:
@@ -662,10 +661,8 @@ std::shared_ptr<Texture> ViewportNode::fetchRenderResult(float simulationProgres
             }
 
         case RenderConfiguration::UpdateMode::ON_FETCH:
-            mTimeSinceLastRender = 0;
-            world->getSystem<RenderSystem>()->useRenderSet(mRenderSet);
-            world->getSystem<RenderSystem>()->execute(simulationProgress);
-            mTextureResult = world->getSystem<RenderSystem>()->getCurrentScreenTexture();
+            render_(simulationProgress);
+
         case RenderConfiguration::UpdateMode::ONCE:
         case RenderConfiguration::UpdateMode::ON_RENDER_CAP_FPS:
         case RenderConfiguration::UpdateMode::ON_RENDER:
@@ -673,16 +670,20 @@ std::shared_ptr<Texture> ViewportNode::fetchRenderResult(float simulationProgres
         break;
     }
 
+    getWorld().lock()->getSystem<RenderSystem>()->useRenderSet(mRenderSet);
+    mTextureResult = getWorld().lock()->getSystem<RenderSystem>()->getCurrentScreenTexture();
+
     return mTextureResult;
 }
 
 std::shared_ptr<Texture> ViewportNode::render(float simulationProgress, uint32_t variableStep) {
     assert(mRenderConfiguration.mFPSCap > 0.f && "FPS cannot be negative or zero");
     const uint32_t thresholdTime {static_cast<uint32_t>(1000 / mRenderConfiguration.mFPSCap)};
-    std::shared_ptr<ECSWorld> world = getWorld().lock();
 
     mTimeSinceLastRender += variableStep;
-    if(mTimeSinceLastRender > thresholdTime) mTimeSinceLastRender = thresholdTime;
+    if(mTimeSinceLastRender > thresholdTime) {
+        mTimeSinceLastRender = thresholdTime;
+    }
     bool renderOnce { false };
 
     switch (mRenderConfiguration.mUpdateMode) {
@@ -695,37 +696,54 @@ std::shared_ptr<Texture> ViewportNode::render(float simulationProgress, uint32_t
                 break;
 
         case RenderConfiguration::UpdateMode::ON_RENDER:
-            mTimeSinceLastRender = 0;
-            world->getSystem<RenderSystem>()->useRenderSet(mRenderSet);
-
-            if(mRenderConfiguration.mRenderType == RenderConfiguration::RenderType::ADDITION) {
-                std::size_t childViewportIndex { 0 };
-                for(auto& childViewport: mChildViewports){
-                    if(std::shared_ptr<Texture> renderResult = childViewport->fetchRenderResult(simulationProgress)) {
-                        world->getSystem<RenderSystem>()->addOrAssignRenderSource(
-                            std::string("textureAddend_") + std::to_string(childViewportIndex++),
-                            renderResult
-                        );
-                    }
-                }
-            }
-
-            world->getSystem<RenderSystem>()->execute(simulationProgress);
-
-            if(mRenderConfiguration.mRenderType == RenderConfiguration::RenderType::ADDITION) {
-                for(std::size_t childViewportIndex { 0 }; childViewportIndex < mChildViewports.size(); ++childViewportIndex) {
-                    world->getSystem<RenderSystem>()->removeRenderSource(
-                        std::string("textureAddend_") + std::to_string(childViewportIndex)
-                    );
-                }
-            }
-
-            mTextureResult = world->getSystem<RenderSystem>()->getCurrentScreenTexture();
-
+            std::cout << mName << "(" << getWorldID() << ")" << " is working" << std::endl;
+            render_(simulationProgress);
         case RenderConfiguration::UpdateMode::ON_FETCH:
         case RenderConfiguration::UpdateMode::ON_FETCH_CAP_FPS:
         case RenderConfiguration::UpdateMode::NEVER:
         break;
+    }
+
+    getWorld().lock()->getSystem<RenderSystem>()->useRenderSet(mRenderSet);
+    mTextureResult = getWorld().lock()->getSystem<RenderSystem>()->getCurrentScreenTexture();
+
+    return mTextureResult;
+}
+
+std::shared_ptr<Texture> ViewportNode::render_(float simulationProgress) {
+
+    mTimeSinceLastRender = 0;
+    std::shared_ptr<ECSWorld> world = getWorld().lock();
+
+    if(mRenderConfiguration.mRenderType == RenderConfiguration::RenderType::ADDITION) {
+        std::size_t childViewportIndex { 0 };
+        std::cout << "\tcombining textures: ";
+        for(auto& childViewport: mChildViewports){
+            if(std::shared_ptr<Texture> renderResult = childViewport->fetchRenderResult(simulationProgress)) {
+                /**
+                    * NOTE: context change might have occurred because of fetchRenderResult. Make our own render set
+                    * active once again
+                    */
+                world->getSystem<RenderSystem>()->useRenderSet(mRenderSet);
+                world->getSystem<RenderSystem>()->addOrAssignRenderSource(
+                    std::string("textureAddend_") + std::to_string(childViewportIndex++),
+                    renderResult
+                );
+                std::cout << renderResult->getTextureID() << ", ";
+            }
+        }
+        std::cout << std::endl;
+    }
+
+    world->getSystem<RenderSystem>()->useRenderSet(mRenderSet);
+    world->getSystem<RenderSystem>()->execute(simulationProgress);
+
+    if(mRenderConfiguration.mRenderType == RenderConfiguration::RenderType::ADDITION) {
+        for(std::size_t childViewportIndex { 0 }; childViewportIndex < mChildViewports.size(); ++childViewportIndex) {
+            world->getSystem<RenderSystem>()->removeRenderSource(
+                std::string("textureAddend_") + std::to_string(childViewportIndex)
+            );
+        }
     }
 
     return mTextureResult;
@@ -745,16 +763,17 @@ std::shared_ptr<const ViewportNode> ViewportNode::getLocalViewport() const {
 std::vector<std::shared_ptr<ViewportNode>> ViewportNode::getActiveDescendantViewports() {
     assert(isActive() && "Can only find active descendant viewports of an active viewport node");
 
-    std::vector<std::shared_ptr<ViewportNode>> activeViewports { {std::static_pointer_cast<ViewportNode>(shared_from_this())} };
+    std::vector<std::shared_ptr<ViewportNode>> activeViewports {};
     for(auto child: mChildViewports) {
         if(!child->isActive()) continue;
-
         std::vector<std::shared_ptr<ViewportNode>> activeDescendantViewports { child->getActiveDescendantViewports() };
         activeViewports.insert(activeViewports.end(), activeDescendantViewports.begin(), activeDescendantViewports.end());
     }
+    activeViewports.push_back(std::static_pointer_cast<ViewportNode>(shared_from_this()));
 
     return activeViewports;
 }
+
 std::vector<std::weak_ptr<ECSWorld>> ViewportNode::getActiveDescendantWorlds() {
     assert(isActive() && "Can only find active descendant worlds of an active viewportNode");
 
@@ -862,7 +881,7 @@ void SceneSystem::render(float simulationProgress, uint32_t variableStep) {
         world.lock()->preRenderStep(variableStep);
     }
 
-    for(std::shared_ptr<ViewportNode> viewport: activeViewports) {
+   for(std::shared_ptr<ViewportNode> viewport: activeViewports) {
         viewport->render(simulationProgress, variableStep);
     }
 

--- a/src/engine/scene_system.hpp
+++ b/src/engine/scene_system.hpp
@@ -327,8 +327,8 @@ private:
     std::vector<std::shared_ptr<ViewportNode>> getActiveDescendantViewports();
     std::vector<std::weak_ptr<ECSWorld>> getActiveDescendantWorlds();
 
-    std::shared_ptr<Texture> render(float simulationProgress, uint32_t variableStep);
-    std::shared_ptr<Texture> render_(float simulationProgress);
+    void render(float simulationProgress, uint32_t variableStep);
+    void render_(float simulationProgress);
 
     ActionDispatch mActionDispatch {};
     std::set<std::shared_ptr<ViewportNode>, std::owner_less<std::shared_ptr<ViewportNode>>> mChildViewports {};

--- a/src/engine/scene_system.hpp
+++ b/src/engine/scene_system.hpp
@@ -268,6 +268,7 @@ public:
     static std::shared_ptr<ViewportNode> create(const std::string& name, bool inheritsWorld, const RenderConfiguration& renderConfiguration);
     static std::shared_ptr<ViewportNode> create(const nlohmann::json& sceneNodeDescription);
     static std::shared_ptr<ViewportNode> copy(const std::shared_ptr<const ViewportNode> other);
+
     static inline std::string getResourceTypeName() { return "ViewportNode"; }
 
     std::shared_ptr<ViewportNode> getLocalViewport() override;
@@ -327,6 +328,7 @@ private:
     std::vector<std::weak_ptr<ECSWorld>> getActiveDescendantWorlds();
 
     std::shared_ptr<Texture> render(float simulationProgress, uint32_t variableStep);
+    std::shared_ptr<Texture> render_(float simulationProgress);
 
     ActionDispatch mActionDispatch {};
     std::set<std::shared_ptr<ViewportNode>, std::owner_less<std::shared_ptr<ViewportNode>>> mChildViewports {};

--- a/src/engine/text_render.cpp
+++ b/src/engine/text_render.cpp
@@ -51,6 +51,7 @@ std::shared_ptr<Texture> TextFont::renderText(
     )};
     ColorBufferDefinition colorBufferDefinition {
         .mDataType { GL_UNSIGNED_BYTE },
+        .mComponentCount { 4 },
         .mUsesWebColors { true }
     };
     SDL_Surface* pretexture { SDL_ConvertSurfaceFormat(renderedText, SDL_PIXELFORMAT_RGBA32, 0) };
@@ -66,7 +67,7 @@ std::shared_ptr<Texture> TextFont::renderText(
     glTexImage2D(GL_TEXTURE_2D, 0,
         deduceInternalFormat(colorBufferDefinition),
         colorBufferDefinition.mDimensions.x, colorBufferDefinition.mDimensions.y,
-        0, deduceExternalFormat(colorBufferDefinition), colorBufferDefinition.mDataType,
+        0, GL_RGBA, GL_UNSIGNED_BYTE,
         reinterpret_cast<void*>(pretexture->pixels)
     );
     SDL_FreeSurface(pretexture);

--- a/src/engine/texture.cpp
+++ b/src/engine/texture.cpp
@@ -235,7 +235,7 @@ std::shared_ptr<IResource> TextureFromFile::createResource(const nlohmann::json&
         //assume linear space if not an albedo texture
         deduceInternalFormat(colorBufferDefinition),
         colorBufferDefinition.mDimensions.x, colorBufferDefinition.mDimensions.y,
-        0, deduceExternalFormat(colorBufferDefinition), colorBufferDefinition.mDataType,
+        0, GL_RGBA, GL_UNSIGNED_BYTE,
         reinterpret_cast<void*>(pretexture->pixels)
     );
     SDL_FreeSurface(pretexture);
@@ -269,8 +269,8 @@ std::shared_ptr<IResource> TextureFromColorBufferDefinition::createResource(cons
             colorBufferDefinition.mDimensions.x,
             colorBufferDefinition.mDimensions.y,
             0, 
-            deduceExternalFormat(colorBufferDefinition),
-            colorBufferDefinition.mDataType,
+            GL_RGBA,
+            GL_UNSIGNED_BYTE,
             NULL
         );
 

--- a/src/shader/basic/basic.fs
+++ b/src/shader/basic/basic.fs
@@ -8,6 +8,6 @@ Include:
 out vec4 outColor;
 
 void main() {
-    outColor = fragAttr.color * texture(uGenericTexture, fragAttr.UV1);
+    outColor = texture(uGenericTexture, fragAttr.UV1);
     // outColor = vec4(1.f);
 }

--- a/src/shader/basic/basic.vs
+++ b/src/shader/basic/basic.vs
@@ -7,7 +7,6 @@ Include:
 
 void main() {
     fragAttr.position = attrPosition;
-    fragAttr.color = attrColor;
     fragAttr.UV1 = attrUV1;
 
     gl_Position = fragAttr.position;

--- a/src/shader/blur/gaussian.fs
+++ b/src/shader/blur/gaussian.fs
@@ -29,4 +29,7 @@ void main() {
             -i * offset + fragAttr.UV1
         );
     }
+    if(dot(outColor, outColor) > 0.f) {
+        outColor.a=1.f;
+    }
 }

--- a/src/shader/combine/combine.fs
+++ b/src/shader/combine/combine.fs
@@ -1,0 +1,16 @@
+uniform int nCombine=0;
+uniform sampler2D uCombineTextures[4];
+
+out vec4 outColor;
+
+void main() {
+    for(int i = 0; i < nCombine; ++i) {
+        vec4 sampledColor = texture(uCombineTextures[i], fragAttr.UV1);
+        if(sampledColor.a > 1.f) sampledColor.a = 1.f;
+
+        vec3 rgbComp = sampledColor.rgb * sampledColor.a + outColor.rgb * (1.f - sampledColor.a);
+        float aComp = max(sampledColor.a, outColor.a);
+        outColor = vec4(rgbComp, aComp);
+    }
+}
+

--- a/src/shader/combineFS.json
+++ b/src/shader/combineFS.json
@@ -1,0 +1,9 @@
+{
+    "name": "combineFS",
+    "type": "shader/fragment",
+    "sources": [
+        "common/versionHeader.glsl",
+        "common/fragmentAttributes.fs",
+        "combine/combine.fs"
+    ]
+}

--- a/src/shader/combineShader.json
+++ b/src/shader/combineShader.json
@@ -1,0 +1,6 @@
+{
+    "name": "combineShader",
+    "type": "shader/program",
+    "vertexShader": "basicVS.json",
+    "fragmentShader": "combineFS.json"
+}

--- a/src/shader/lighting/deferredLighting.fs
+++ b/src/shader/lighting/deferredLighting.fs
@@ -68,11 +68,9 @@ void main() {
     vec4 componentAmbient = fragAttrLightEmission.mAmbientColor * gAlbedo;
 
     outColor = ((componentDiffuse) + (componentSpecular) + (componentAmbient)) * factorAttenuation * factorSpotIntensity;
-    if(gPosition.w > 0.f) {
-        outColor.a = 1.f;
-    } else {
-        outColor.a = 0.f;
-    }
+
+    outColor.a = dot(gPosition, gPosition) > 0.f? 1.f: 0.f;
+
     if(dot(outColor.xyz, vec3(.2f, .7f, .1f)) >= uBrightCutoff) {
         brightColor = outColor;
     }

--- a/src/shader/simple_tonemapping/tonemapping.fs
+++ b/src/shader/simple_tonemapping/tonemapping.fs
@@ -17,4 +17,5 @@ void main() {
     outColor = 1.f - exp(uExposure * (-inColor));
     outColor = pow(outColor, vec4(1.f/uGamma));
     outColor.a = inColor.a;
+    // outColor = vec4(inColor.a);
 }


### PR DESCRIPTION
## Obervations:

- Flickering goes away when the second viewport under viewport_3D’s world is removed

- Flickering’s frequency is roughly proportional to the fps_cap of the background viewport

- The addition viewport’s (here, the root viewport) fps_cap determines how soon after blinking out the background texture returns

- Setting the viewport_3d->viewport’s dimensions to a fraction of their earlier size does not change flickering behaviour. Only its complete removal changes anything

## An analysis of the cause of the bug (hopefully):

### Key observations:

If the reflection was rendered before the UI,  and the UI was rendered before the 3D scene, the UI does not appear in the background until the next frame.

If the reflection was rendered before the UI, and the 3D scene was never re-rendered, then the UI does not ever appear in the background no matter how many times the frame is re-rendered.  It is only after the 3D scene is rendered immediately followed by the UI that the UI reappears in the background.

If the procedure to cause the UI to disappear from the background is followed, and we directly render the UI viewport’s result to the screen, we find the screen completely blank.

### Some context:

There are 3 viewports that are added together to an additional 4th root viewport to make up the scene:

- **The 3D viewport:** This is the main (test) scene.  This viewport's camera is oriented along the -Z axis, with its position offset by 1 unit.

- **The reflection viewport:** The reflective ball set in the middle of the scene receives its albedo texture from here.  It shares the same world as the 3D viewport, and its camera is permanently pointed upwards, above the ball.

- **The UI viewport:**  This is also a 3D scene like the 3D viewport, but it exists just to help me test the pipeline.  It exists in a different world from 3D and reflection viewports.  Its camera is configured almost identically to the 3D viewport’s camera.

- **The root viewport:** This is a viewport whose only purpose is to sum the result textures from its immediate child viewports.  It acts essentially as a texture compositor, and does not interact with the camera system.

### The cause:

![image](https://github.com/user-attachments/assets/fc1b8f67-98f1-4a58-9c6a-30b3f8ad2ae5)
mMatrixUniformBufferBinding is 0 for all instances of the render system, at present.  Each instance of RenderSystem however receives its own mMatrixUniformBufferIndex.

![image](https://github.com/user-attachments/assets/deb20089-866b-426e-bed4-3bf7fe3828d2)
mMatrixUniformBufferIndex is common across render sets within the same render system/world.  This is the uniform buffer index belonging to both the 3D scene viewport and the reflection viewport.  Its value is 3.

![image](https://github.com/user-attachments/assets/42f9c9a2-385d-41e2-b60c-dd0579655eca)
The UI camera matrices are being fetched correctly from this render system’s world;  the matrices are also being sent to the right place on the GPU (the uniform buffer corresponding with index 2).  The problem is that this uniform buffer (the one belonging to the UI viewport) is never bound to the correct uniform buffer binding point, i.e., 0.  The only camera matrices that are being used are the ones belonging to the 3D scene and reflection viewports, i.e., the ones found under uniform buffer index 3.

In effect, the only viewport whose matrix buffer was being used was the 3D world’s, since its render system was the last to be initialized.  It just so happened that at the start, the 3D world’s camera and the UI camera had almost the same placement, so the UI viewport had the appearance of being rendered correctly.

The problem would have been made immediately obvious if I’d had the ability to control the camera of the 3D scene.  I could not do that because I hadn’t gotten around to implementing a mechanism for passing inputs through from parent viewports to child viewports.

## The solution:

![image](https://github.com/user-attachments/assets/d52ba9f3-1317-4a72-943f-2c9b47ea60a5)
Bind the uniform camera matrix buffer before running all the stages in our rendering pipeline.